### PR TITLE
Tx error handling during send (from either `broadcast` and `retry`)

### DIFF
--- a/atxm/exceptions.py
+++ b/atxm/exceptions.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-from web3.types import PendingTx, RPCError, TxReceipt
+from web3.types import PendingTx, TxReceipt
 
 
 class Fault(Enum):
@@ -13,9 +13,6 @@ class Fault(Enum):
     # Strategy has been running for too long
     TIMEOUT = "timeout"
 
-    # Transaction has been capped and subsequently timed out
-    PAUSE = "pause"
-
     # Transaction reverted
     REVERT = "revert"
 
@@ -26,7 +23,7 @@ class Fault(Enum):
     INSUFFICIENT_FUNDS = "insufficient_funds"
 
 
-class InsufficientFunds(RPCError):
+class InsufficientFunds(Exception):
     """raised when a transaction exceeds the spending cap"""
 
 

--- a/atxm/exceptions.py
+++ b/atxm/exceptions.py
@@ -30,13 +30,6 @@ class InsufficientFunds(RPCError):
     """raised when a transaction exceeds the spending cap"""
 
 
-class Wait(Exception):
-    """
-    Raised when a strategy exceeds a limitation.
-    Used to mark a pending transaction as "wait, don't retry".
-    """
-
-
 class TransactionFaulted(Exception):
     """Raised when a transaction has been faulted."""
 

--- a/atxm/machine.py
+++ b/atxm/machine.py
@@ -429,7 +429,7 @@ class _Machine(StateMachine):
                 )
                 hook = future_tx.on_broadcast_failure
                 if hook:
-                    fire_hook(hook=hook, tx=future_tx, error=e)
+                    fire_hook(hook, future_tx, e)
             return
 
         self._tx_tracker.morph(tx=future_tx, txhash=txhash)

--- a/atxm/machine.py
+++ b/atxm/machine.py
@@ -289,7 +289,7 @@ class _Machine(StateMachine):
             raise ValueError(f"Signer {address} not found")
         return signer
 
-    def __fire(self, tx: AsyncTx, msg: str) -> Optional[TxHash]:
+    def __fire(self, tx: AsyncTx, msg: str) -> TxHash:
         """
         Signs and broadcasts a transaction, handling RPC errors
         and internal state changes.

--- a/atxm/machine.py
+++ b/atxm/machine.py
@@ -384,7 +384,7 @@ class _Machine(StateMachine):
                 if tx in self._tx_tracker.finalized:
                     self._tx_tracker.finalized.remove(tx)
                     self.log.info(
-                        f"[clear] stopped tracking {tx.txhash.hex()} after {confirmations} confirmations"
+                        f"[monitor] stopped tracking {tx.txhash.hex()} after {confirmations} confirmations"
                     )
                 continue
             self.log.info(

--- a/atxm/machine.py
+++ b/atxm/machine.py
@@ -20,7 +20,6 @@ from atxm.exceptions import (
 from atxm.strategies import (
     AsyncTxStrategy,
     ExponentialSpeedupStrategy,
-    InsufficientFundsPause,
     TimeoutStrategy,
 )
 from atxm.tracker import _TxTracker
@@ -97,7 +96,6 @@ class _Machine(StateMachine):
     _BLOCK_SAMPLE_SIZE = 10_000  # blocks
 
     STRATEGIES: List[Type[AsyncTxStrategy]] = [
-        InsufficientFundsPause,
         TimeoutStrategy,
         ExponentialSpeedupStrategy,
     ]

--- a/atxm/machine.py
+++ b/atxm/machine.py
@@ -12,7 +12,7 @@ from web3.types import TxParams
 from atxm.exceptions import TransactionFaulted, TransactionReverted
 from atxm.strategies import (
     AsyncTxStrategy,
-    FixedRateSpeedUp,
+    ExponentialSpeedupStrategy,
     InsufficientFundsPause,
     TimeoutStrategy,
 )
@@ -92,7 +92,7 @@ class _Machine(StateMachine):
     STRATEGIES: List[Type[AsyncTxStrategy]] = [
         InsufficientFundsPause,
         TimeoutStrategy,
-        FixedRateSpeedUp,
+        ExponentialSpeedupStrategy,
     ]
 
     class LogObserver:

--- a/atxm/strategies.py
+++ b/atxm/strategies.py
@@ -30,7 +30,7 @@ class AsyncTxStrategy(ABC):
         """Used to identify the strategy in logs."""
         return self._NAME
 
-    def execute(self, pending: PendingTx) -> TxParams:
+    def execute(self, pending: PendingTx) -> Optional[TxParams]:
         """
         Execute the strategy.
 
@@ -40,9 +40,10 @@ class AsyncTxStrategy(ABC):
         (like tx.txhash, tx.params, tx.created, etc).
 
         This method must do one of the following:
-        - Raise `Wait` to pause retries and wait around for a bit.
-        - Raise `Fault`to signal the transaction cannot be retried.
-        - Returns a TxParams dictionary to use in the next attempt.
+        - Raise `TransactionFaulted`to signal the transaction cannot be retried.
+        - Returns an updated TxParams dictionary to use in the next attempt.
+        - Returns None if the strategy makes no changes to the existing TxParams and
+          signal that the machine should just wait for the existing tx
 
         NOTE: Do not mutate the input `tx` object. Return a new TxParams
         dictionary with the updated transaction parameters. The input

--- a/atxm/strategies.py
+++ b/atxm/strategies.py
@@ -111,12 +111,12 @@ class TimeoutStrategy(AsyncTxStrategy):
         human_end_time = end_time.strftime("%Y-%m-%d %H:%M:%S")
         if time_remaining.seconds < (self.timeout * self._WARN_FACTOR):
             self.log.warn(
-                f"[pending_timeout] Transaction {pending.txhash.hex()} will timeout in "
+                f"[timeout] Transaction {pending.txhash.hex()} will timeout in "
                 f"{time_remaining} at {human_end_time}"
             )
         else:
             self.log.info(
-                f"[pending] {pending.txhash.hex()} "
+                f"[timeout] {pending.txhash.hex()} "
                 f"{elapsed_time.seconds}s Elapsed | "
                 f"{time_remaining} Remaining | "
                 f"Timeout at {human_end_time}"

--- a/atxm/strategies.py
+++ b/atxm/strategies.py
@@ -248,6 +248,8 @@ class ExponentialSpeedupStrategy(AsyncTxStrategy):
             suggested_tip, new_tip, new_max_fee = self._calculate_eip1559_speedup_fee(
                 params
             )
+
+            # TODO: is this the best way of setting a cap?
             if new_tip > (suggested_tip * self.max_tip_factor):
                 # nothing the strategy can do here - don't change the params
                 log.warn(

--- a/atxm/strategies.py
+++ b/atxm/strategies.py
@@ -180,12 +180,12 @@ class ExponentialSpeedupStrategy(AsyncTxStrategy):
         _log_gas_weather(current_base_fee, suggested_tip)
 
         # default to 1 if not specified in tx
-        prior_max_priority_fee = params.get("maxPriorityFeePerGas", 0)
+        prior_max_priority_fee = params.get(self._MAX_PRIORITY_FEE_PER_GAS_FIELD, 0)
         updated_max_priority_fee = math.ceil(
             max(prior_max_priority_fee, suggested_tip) * self.speedup_factor
         )
 
-        current_max_fee_per_gas = params.get("maxFeePerGas")
+        current_max_fee_per_gas = params.get(self._MAX_FEE_PER_GAS_FIELD)
         if current_max_fee_per_gas:
             # already previously set, just increase by factor but ensure base fee hasn't
             # also increased. The defaults used by web3py for this value is already pretty
@@ -244,7 +244,7 @@ class ExponentialSpeedupStrategy(AsyncTxStrategy):
             if new_tip > (suggested_tip * self.max_tip_factor):
                 # nothing the strategy can do here - don't change the params
                 log.warn(
-                    f"[speedup] Increasing pending transaction's maxPriorityFeePerGas "
+                    f"[speedup] Increasing pending transaction's {self._MAX_PRIORITY_FEE_PER_GAS_FIELD} "
                     f"to {round(Web3.from_wei(new_tip, 'gwei'), 4)} gwei will exceed "
                     f"spending cap factor {self.max_tip_factor}x over suggested tip "
                     f"({round(Web3.from_wei(suggested_tip, 'gwei'), 4)} gwei); "

--- a/atxm/strategies.py
+++ b/atxm/strategies.py
@@ -91,7 +91,7 @@ class TimeoutStrategy(AsyncTxStrategy):
 
     _TIMEOUT = 60 * 60  # 1 hour in seconds
 
-    _WARN_FACTOR = 0.05  # 10% of timeout remaining
+    _WARN_FACTOR = 0.05  # 5% of timeout remaining
 
     def __init__(self, w3: Web3, timeout: Optional[int] = None):
         super().__init__(w3)

--- a/atxm/strategies.py
+++ b/atxm/strategies.py
@@ -139,8 +139,11 @@ class TimeoutStrategy(AsyncTxStrategy):
         return None
 
 
-class FixedRateSpeedUp(AsyncTxStrategy):
-    """Speedup strategy for pending transactions."""
+class ExponentialSpeedupStrategy(AsyncTxStrategy):
+    """
+    Speedup strategy for pending transactions that increases fees by a
+    percentage over the prior value every time it is used.
+    """
 
     _SPEEDUP_INCREASE_PERCENTAGE = 0.125  # 12.5%
 

--- a/atxm/strategies.py
+++ b/atxm/strategies.py
@@ -70,7 +70,7 @@ class InsufficientFundsPause(AsyncTxStrategy):
     _NAME = "insufficient-funds"
 
     def execute(self, pending: PendingTx) -> Optional[TxParams]:
-        balance = self.w3.eth.get_balance(pending._from)
+        balance = self.w3.eth.get_balance(pending.params["from"])
         if balance == 0:
             self.log.warn(
                 f"Insufficient funds for transaction #{pending.params['nonce']}"

--- a/atxm/strategies.py
+++ b/atxm/strategies.py
@@ -64,26 +64,6 @@ class AsyncTxStrategy(ABC):
         raise NotImplementedError
 
 
-class InsufficientFundsPause(AsyncTxStrategy):
-    """Pause strategy for pending transactions."""
-
-    _NAME = "insufficient-funds"
-
-    def execute(self, pending: PendingTx) -> Optional[TxParams]:
-        balance = self.w3.eth.get_balance(pending.params["from"])
-        if balance == 0:
-            self.log.warn(
-                f"Insufficient funds for transaction #{pending.params['nonce']}"
-            )
-            raise TransactionFaulted(
-                tx=pending,
-                fault=Fault.INSUFFICIENT_FUNDS,
-                message="Insufficient funds",
-            )
-        # log.warn(f"Insufficient funds for transaction #{pending.params['nonce']}")
-        return None
-
-
 class TimeoutStrategy(AsyncTxStrategy):
     """Timeout strategy for pending transactions."""
 

--- a/atxm/strategies.py
+++ b/atxm/strategies.py
@@ -236,7 +236,7 @@ class ExponentialSpeedupStrategy(AsyncTxStrategy):
             old_gas_price = params[self._GAS_PRICE_FIELD]
             new_gas_price = self._calculate_legacy_speedup_fee(pending.params)
             log.info(
-                f"[speedup] Speeding up legacy transaction #atx-{pending.id} (nonce=#{params['nonce']}) \n"
+                f"[speedup] Speeding up legacy transaction #atx-{pending.id} (nonce={params['nonce']}) \n"
                 f"gasPrice {old_gas_price} -> {new_gas_price}"
             )
             params[self._GAS_PRICE_FIELD] = new_gas_price
@@ -272,7 +272,7 @@ class ExponentialSpeedupStrategy(AsyncTxStrategy):
                 else "undefined"
             )
             log.info(
-                f"[speedup] Speeding up transaction #atx-{pending.id} (nonce=#{params['nonce']}) \n"
+                f"[speedup] Speeding up transaction #atx-{pending.id} (nonce={params['nonce']}) \n"
                 f"{self._MAX_PRIORITY_FEE_PER_GAS_FIELD} {tip_increase_message} -> {new_tip} \n"
                 f"{self._MAX_FEE_PER_GAS_FIELD} {fee_increase_message} -> {new_max_fee}"
             )

--- a/atxm/strategies.py
+++ b/atxm/strategies.py
@@ -189,7 +189,9 @@ class FixedRateSpeedUp(AsyncTxStrategy):
             # high so don't overdo the multiplication factor.
             updated_max_fee_per_gas = math.ceil(
                 max(
+                    # last attempt param
                     current_max_fee_per_gas * self.speedup_factor,
+                    # OR take current conditions and speedup
                     (current_base_fee * self.speedup_factor) + updated_max_priority_fee,
                 )
             )
@@ -202,7 +204,9 @@ class FixedRateSpeedUp(AsyncTxStrategy):
         return suggested_tip, updated_max_priority_fee, updated_max_fee_per_gas
 
     def _calculate_legacy_speedup_fee(self, params: TxParams) -> int:
-        generated_gas_price = self.w3.eth.generate_gas_price(params) or 0
+        generated_gas_price = (
+            self.w3.eth.generate_gas_price(params) or 0
+        )  # 0 means no gas strategy
         old_gas_price = params[self._GAS_PRICE_FIELD]
 
         base_price_to_increase = old_gas_price

--- a/atxm/strategies.py
+++ b/atxm/strategies.py
@@ -147,6 +147,8 @@ class ExponentialSpeedupStrategy(AsyncTxStrategy):
 
     _SPEEDUP_INCREASE_PERCENTAGE = 0.125  # 12.5%
 
+    _MIN_SPEEDUP_INCREASE = 0.10  # mandated by eth standard
+
     _MAX_TIP_FACTOR = 3  # max 3x over suggested tip
 
     _NAME = "speedup"
@@ -163,7 +165,10 @@ class ExponentialSpeedupStrategy(AsyncTxStrategy):
     ):
         super().__init__(w3)
 
-        if speedup_increase_percentage > 1 or speedup_increase_percentage < 0.10:
+        if (
+            speedup_increase_percentage < self._MIN_SPEEDUP_INCREASE
+            or speedup_increase_percentage > 1
+        ):
             raise ValueError(
                 f"Invalid speedup increase percentage {speedup_increase_percentage}; "
                 f"must be in range [0.10, 1]"

--- a/atxm/strategies.py
+++ b/atxm/strategies.py
@@ -260,11 +260,5 @@ class FixedRateSpeedUp(AsyncTxStrategy):
             params[self._MAX_PRIORITY_FEE_PER_GAS_FIELD] = new_tip
             params[self._MAX_FEE_PER_GAS_FIELD] = new_max_fee
 
-        latest_nonce = self.w3.eth.get_transaction_count(params["from"], "latest")
-        pending_nonce = self.w3.eth.get_transaction_count(params["from"], "pending")
-        if pending_nonce - latest_nonce > 0:
-            log.warn("Overriding pending transaction!")
-
-        params["nonce"] = latest_nonce
         params = TxParams(params)
         return params

--- a/atxm/tracker.py
+++ b/atxm/tracker.py
@@ -6,7 +6,6 @@ from json import JSONDecodeError
 from pathlib import Path
 from typing import Callable, Deque, Dict, Optional, Set, Tuple
 
-from eth_typing import ChecksumAddress
 from web3.types import TxParams, TxReceipt
 
 from atxm.exceptions import TransactionFaulted
@@ -207,7 +206,6 @@ class _TxTracker:
     def _queue(
         self,
         params: TxParams,
-        _from: ChecksumAddress,
         info: Dict[str, str] = None,
         on_broadcast: Optional[Callable[[PendingTx], None]] = None,
         on_finalized: Optional[Callable[[FinalizedTx], None]] = None,
@@ -215,7 +213,6 @@ class _TxTracker:
     ) -> FutureTx:
         """Queue a new transaction for broadcast and subsequent tracking."""
         tx = FutureTx(
-            _from=_from,
             id=self.__COUNTER,
             params=params,
             info=info,

--- a/atxm/tracker.py
+++ b/atxm/tracker.py
@@ -208,6 +208,7 @@ class _TxTracker:
         params: TxParams,
         info: Dict[str, str] = None,
         on_broadcast: Optional[Callable[[PendingTx], None]] = None,
+        on_broadcast_failure: Optional[Callable[[FutureTx, Exception], None]] = None,
         on_finalized: Optional[Callable[[FinalizedTx], None]] = None,
         on_fault: Optional[Callable[[FaultedTx], None]] = None,
     ) -> FutureTx:
@@ -220,6 +221,7 @@ class _TxTracker:
 
         # configure hooks
         tx.on_broadcast = on_broadcast
+        tx.on_broadcast_failure = on_broadcast_failure
         tx.on_finalized = on_finalized
         tx.on_fault = on_fault
 

--- a/atxm/tracker.py
+++ b/atxm/tracker.py
@@ -101,6 +101,17 @@ class _TxTracker:
             return
         log.debug(f"[tracker] tracked active transaction {tx.txhash.hex()}")
 
+    def update_after_retry(self, tx: PendingTx) -> PendingTx:
+        if tx.id != self.__active.id:
+            raise RuntimeError(
+                f"Trying to update unexpected active tx: from {self.__active.id} to {tx.id}"
+            )
+
+        self.__active.txhash = tx.txhash
+        self.__active.params = tx.params
+
+        return self.pending
+
     def morph(self, tx: FutureTx, txhash: TxHash) -> PendingTx:
         """
         Morphs a future transaction into a pending transaction.

--- a/atxm/tx.py
+++ b/atxm/tx.py
@@ -15,6 +15,7 @@ TxHash = HexBytes
 @dataclass
 class AsyncTx(ABC):
     id: int
+    params: TxParams
     final: bool = field(default=None, init=False)
     fault: Optional[Fault] = field(default=None, init=False)
     on_broadcast: Optional[Callable[[PendingTx], None]] = field(
@@ -49,17 +50,18 @@ class AsyncTx(ABC):
 @dataclass
 class FutureTx(AsyncTx):
     final: bool = field(default=False, init=False)
-    params: TxParams
-    _from: ChecksumAddress
     info: Optional[Dict] = None
 
     def __hash__(self):
         return hash(self.id)
 
+    @property
+    def _from(self) -> ChecksumAddress:
+        return self.params["from"]
+
     def to_dict(self) -> Dict:
         return {
             "id": self.id,
-            "from": self._from,
             "params": _serialize_tx_params(self.params),
             "info": self.info,
         }
@@ -68,7 +70,6 @@ class FutureTx(AsyncTx):
     def from_dict(cls, data: Dict):
         return cls(
             id=int(data["id"]),
-            _from=data["from"],
             params=TxParams(data["params"]),
             info=dict(data["info"]),
         )

--- a/atxm/tx.py
+++ b/atxm/tx.py
@@ -5,7 +5,7 @@ from typing import Callable, Dict, Optional
 from eth_typing import ChecksumAddress
 from eth_utils import encode_hex
 from hexbytes import HexBytes
-from web3.types import PendingTx, TxData, TxParams, TxReceipt
+from web3.types import TxData, TxParams, TxReceipt
 
 from atxm.exceptions import Fault
 
@@ -18,7 +18,10 @@ class AsyncTx(ABC):
     params: TxParams
     final: bool = field(default=None, init=False)
     fault: Optional[Fault] = field(default=None, init=False)
-    on_broadcast: Optional[Callable[[PendingTx], None]] = field(
+    on_broadcast: Optional[Callable[["PendingTx"], None]] = field(
+        default=None, init=False
+    )
+    on_broadcast_failure: Optional[Callable[["FutureTx", Exception], None]] = field(
         default=None, init=False
     )
     on_finalized: Optional[Callable[["FinalizedTx"], None]] = field(

--- a/atxm/utils.py
+++ b/atxm/utils.py
@@ -31,10 +31,12 @@ def _get_average_blocktime(w3: Web3, sample_size: int) -> float:
     return average_block_time
 
 
-def _log_gas_weather(base_fee: Wei, tip: Wei) -> None:
+def _log_gas_weather(base_fee: Wei, suggested_tip: Wei) -> None:
     base_fee_gwei = Web3.from_wei(base_fee, "gwei")
-    tip_gwei = Web3.from_wei(tip, "gwei")
-    log.info(f"Gas conditions: base {base_fee_gwei} gwei | tip {tip_gwei} gwei")
+    tip_gwei = Web3.from_wei(suggested_tip, "gwei")
+    log.info(
+        f"[gas] Gas conditions: base {base_fee_gwei} gwei | max tip {tip_gwei} gwei"
+    )
 
 
 def _get_receipt_from_txhash(w3: Web3, txhash: TxHash) -> Optional[TxReceipt]:

--- a/atxm/utils.py
+++ b/atxm/utils.py
@@ -102,7 +102,7 @@ def _get_confirmations(w3: Web3, tx: Union[PendingTx, FinalizedTx]) -> int:
     return confirmations
 
 
-def fire_hook(hook: Callable, tx: AsyncTx, *args, **kwargs) -> None:
+def fire_hook(hook: Callable, tx: AsyncTx, *args) -> None:
     """
     Fire a callable in a separate thread.
     Try exceptionally hard not to crash the async tasks during dispatch.
@@ -112,7 +112,7 @@ def fire_hook(hook: Callable, tx: AsyncTx, *args, **kwargs) -> None:
         def _hook() -> None:
             """I'm inside a thread!"""
             try:
-                hook(tx, *args, **kwargs)
+                hook(tx, *args)
             except Exception as e:
                 log.warn(f"[hook] raised {e}")
 

--- a/atxm/utils.py
+++ b/atxm/utils.py
@@ -35,7 +35,7 @@ def _log_gas_weather(base_fee: Wei, suggested_tip: Wei) -> None:
     base_fee_gwei = Web3.from_wei(base_fee, "gwei")
     tip_gwei = Web3.from_wei(suggested_tip, "gwei")
     log.info(
-        f"[gas] Gas conditions: base {base_fee_gwei} gwei | max tip {tip_gwei} gwei"
+        f"[gas] Gas conditions: base {base_fee_gwei} gwei | suggested tip {tip_gwei} gwei"
     )
 
 

--- a/atxm/utils.py
+++ b/atxm/utils.py
@@ -4,7 +4,12 @@ from typing import Callable, Optional, Union
 from cytoolz import memoize
 from twisted.internet import reactor
 from web3 import Web3
-from web3.exceptions import TransactionNotFound
+from web3.exceptions import (
+    ProviderConnectionError,
+    TimeExhausted,
+    TooManyRequests,
+    TransactionNotFound,
+)
 from web3.types import TxData, TxParams
 from web3.types import TxReceipt, Wei
 
@@ -148,3 +153,7 @@ def _make_tx_params(data: TxData) -> TxParams:
         raise ValueError(f"unrecognized tx data: {data}")
 
     return params
+
+
+def _is_recoverable_send_tx_error(e: Exception) -> bool:
+    return isinstance(e, (TooManyRequests, ProviderConnectionError, TimeExhausted))

--- a/atxm/utils.py
+++ b/atxm/utils.py
@@ -13,7 +13,7 @@ from atxm.exceptions import (
     TransactionReverted,
 )
 from atxm.logging import log
-from atxm.tx import AsyncTx, FinalizedTx, FutureTx, PendingTx, TxHash
+from atxm.tx import AsyncTx, FinalizedTx, PendingTx, TxHash
 
 
 @memoize
@@ -116,7 +116,7 @@ def fire_hook(hook: Callable, tx: AsyncTx, *args, **kwargs) -> None:
         log.info(f"[hook] fired hook {hook} for transaction #atx-{tx.id}")
 
 
-def _handle_rpc_error(e: Exception, tx: FutureTx) -> None:
+def _handle_rpc_error(e: Exception, tx: AsyncTx) -> None:
     try:
         error = RPCError(**e.args[0])
     except TypeError:
@@ -149,6 +149,7 @@ def _make_tx_params(data: TxData) -> TxParams:
             "nonce": data["nonce"],
             "chainId": data["chainId"],
             "gas": data["gas"],
+            "from": data["from"],
             "to": data["to"],
             "value": data["value"],
             "data": data.get("data", b""),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ def legacy_transaction(account, w3):
     params = {
         "chainId": 1337,
         "nonce": 0,
+        "from": account.address,
         "to": account.address,
         "value": 0,
         "gas": 21000,
@@ -44,6 +45,7 @@ def eip1559_transaction(account, w3):
     params = {
         "chainId": 1337,
         "nonce": 0,
+        "from": account.address,
         "to": account.address,
         "value": 0,
         "gas": 21000,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from typing import List, Tuple
 
 import pytest
 from eth_account import Account
+from eth_tester import EthereumTester
 from statemachine import State
 from twisted.internet.task import Clock
 from twisted.logger import globalLogPublisher, textFileLogObserver
@@ -28,7 +29,6 @@ def legacy_transaction(account, w3):
     params = {
         "chainId": 1337,
         "nonce": 0,
-        "from": account.address,
         "to": account.address,
         "value": 0,
         "gas": 21000,
@@ -45,7 +45,6 @@ def eip1559_transaction(account, w3):
     params = {
         "chainId": 1337,
         "nonce": 0,
-        "from": account.address,
         "to": account.address,
         "value": 0,
         "gas": 21000,
@@ -86,6 +85,18 @@ def mock_wake_sleep(machine, mocker):
     wake = mocker.patch.object(machine, "_wake")
     sleep = mocker.patch.object(machine, "_sleep")
     return wake, sleep
+
+
+@pytest.fixture
+def disable_auto_mining(ethereum_tester):
+    ethereum_tester.disable_auto_mine_transactions()
+    yield
+    ethereum_tester.enable_auto_mine_transactions()
+
+
+@pytest.fixture
+def ethereum_tester(w3) -> EthereumTester:
+    return w3.provider.ethereum_tester
 
 
 class StateObserver:

--- a/tests/test_faults.py
+++ b/tests/test_faults.py
@@ -83,6 +83,8 @@ def test_strategy_fault(
     w3, machine, clock, eip1559_transaction, account, interval, mock_wake_sleep, mocker
 ):
     faulty_strategy = mocker.Mock(spec=AsyncTxStrategy)
+
+    # TODO: consider whether strategies should just be overriden through the constructor
     machine._strategies.insert(0, faulty_strategy)  # add first
 
     atx, fault_hook = _broadcast_tx(machine, eip1559_transaction, account, mocker)

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -112,8 +112,6 @@ def test_speedup_strategy_legacy_tx(w3, legacy_transaction, mocker):
     )
     assert speedup_strategy.name == "speedup"
 
-    transaction_count = legacy_transaction["nonce"]
-    mocker.patch.object(w3.eth, "get_transaction_count", return_value=transaction_count)
     pending_tx = mocker.Mock(spec=PendingTx)
     pending_tx.id = 1
 

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -39,7 +39,7 @@ def test_timeout_strategy(w3, mocker):
 
     # 1) tx just created a does not time out
     for i in range(3):
-        assert timeout_strategy.execute(pending_tx) == params
+        assert timeout_strategy.execute(pending_tx) is None  # no change to params
 
     # 2) remaining time is < warn factor; still doesn't time out but we warn about it
     pending_tx.created = (
@@ -53,7 +53,7 @@ def test_timeout_strategy(w3, mocker):
             warnings.append(event)
 
     globalLogPublisher.addObserver(warning_trapper)
-    assert timeout_strategy.execute(pending_tx) == params
+    assert timeout_strategy.execute(pending_tx) is None  # no change to params
     globalLogPublisher.removeObserver(warning_trapper)
 
     assert len(warnings) == 1
@@ -65,7 +65,7 @@ def test_timeout_strategy(w3, mocker):
 
     # 3) close to timeout but not quite (5s short)
     pending_tx.created = (now - timedelta(seconds=(TIMEOUT - 5))).timestamp()
-    assert timeout_strategy.execute(pending_tx) == params
+    assert timeout_strategy.execute(pending_tx) is None  # no change to params
 
     # 4) timeout
     pending_tx.created = (now - timedelta(seconds=(TIMEOUT + 1))).timestamp()

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -14,15 +14,28 @@ from atxm.tx import PendingTx
 
 
 def test_timeout_strategy(w3, mocker):
-    TIMEOUT = 600  # 10 mins
+    TIMEOUT = 900  # 15 mins
 
     # default timeout
     timeout_strategy = TimeoutStrategy(w3)
     assert timeout_strategy.timeout == TimeoutStrategy._TIMEOUT
+    assert (
+        timeout_strategy._warn_threshold
+        == TimeoutStrategy._TIMEOUT * TimeoutStrategy._WARN_FACTOR
+    )
+
+    # specific timeout - low timeout
+    low_timeout = 60  # 60s
+    timeout_strategy = TimeoutStrategy(w3, timeout=low_timeout)
+    assert timeout_strategy.timeout == low_timeout
+    assert (
+        timeout_strategy._warn_threshold == 30
+    )  # timeout so low that max warn threshold hit
 
     # specific timeout
     timeout_strategy = TimeoutStrategy(w3, timeout=TIMEOUT)
     assert timeout_strategy.timeout == TIMEOUT
+    assert timeout_strategy._warn_threshold == TIMEOUT * TimeoutStrategy._WARN_FACTOR
 
     assert timeout_strategy.name == timeout_strategy._NAME
 

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 import pytest
 from hexbytes import HexBytes
 from twisted.logger import LogLevel, globalLogPublisher
-from web3.types import Gwei, TxParams
+from web3.types import TxParams
 
 from atxm.exceptions import Fault, TransactionFaulted
 from atxm.strategies import FixedRateSpeedUp, TimeoutStrategy
@@ -76,13 +76,14 @@ def test_timeout_strategy(w3, mocker):
 
 def test_speedup_strategy(w3, eip1559_transaction, mocker):
     # invalid increase percentage
-    for speedup_perc in [-1, -0.24, 0, 1, 1.01, 1.1]:
+    for speedup_perc in [-1, -0.24, 0, 1.01, 1.1]:
         with pytest.raises(ValueError):
-            _ = FixedRateSpeedUp(w3=w3, speedup_percentage=speedup_perc)
+            _ = FixedRateSpeedUp(w3=w3, speedup_increase_percentage=speedup_perc)
 
     # invalid max tip
-    with pytest.raises(ValueError):
-        _ = FixedRateSpeedUp(w3=w3, max_tip=Gwei(0))
+    for max_tip in [-1, 0, 0.5, 0.9, 1]:
+        with pytest.raises(ValueError):
+            _ = FixedRateSpeedUp(w3=w3, max_tip_factor=max_tip)
 
     speedup_strategy = FixedRateSpeedUp(w3)
     assert speedup_strategy.name == "speedup"

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1,3 +1,4 @@
+import math
 from datetime import datetime, timedelta
 
 import pytest
@@ -74,7 +75,7 @@ def test_timeout_strategy(w3, mocker):
     e.message = "Transaction has timed out"
 
 
-def test_speedup_strategy(w3, eip1559_transaction, mocker):
+def test_speedup_strategy_constructor(w3):
     # invalid increase percentage
     for speedup_perc in [-1, -0.24, 0, 1.01, 1.1]:
         with pytest.raises(ValueError):
@@ -85,5 +86,83 @@ def test_speedup_strategy(w3, eip1559_transaction, mocker):
         with pytest.raises(ValueError):
             _ = FixedRateSpeedUp(w3=w3, max_tip_factor=max_tip)
 
-    speedup_strategy = FixedRateSpeedUp(w3)
+    # defaults
+    speedup_strategy = FixedRateSpeedUp(w3=w3)
+    assert speedup_strategy.speedup_factor == (
+        1 + FixedRateSpeedUp._SPEEDUP_INCREASE_PERCENTAGE
+    )
+    assert speedup_strategy.max_tip_factor == FixedRateSpeedUp._MAX_TIP_FACTOR
+
+    # other values
+    speedup_increase = 0.223
+    max_tip_factor = 4
+    speedup_strategy = FixedRateSpeedUp(
+        w3=w3,
+        speedup_increase_percentage=speedup_increase,
+        max_tip_factor=max_tip_factor,
+    )
+    assert speedup_strategy.speedup_factor == (1 + speedup_increase)
+    assert speedup_strategy.max_tip_factor == max_tip_factor
+
+
+def test_speedup_strategy_legacy_tx(w3, legacy_transaction, mocker):
+    speedup_percentage = 0.112  # 11.2%
+    speedup_strategy = FixedRateSpeedUp(
+        w3, speedup_increase_percentage=speedup_percentage
+    )
     assert speedup_strategy.name == "speedup"
+
+    transaction_count = legacy_transaction["nonce"]
+    mocker.patch.object(w3.eth, "get_transaction_count", return_value=transaction_count)
+    pending_tx = mocker.Mock(spec=PendingTx)
+    pending_tx.id = 1
+
+    # legacy transaction - keep speeding up
+
+    # generated gas price < existing tx gas price
+    generated_gas_price = legacy_transaction["gasPrice"] - 1  # < what is in tx
+    mocker.patch.object(w3.eth, "generate_gas_price", return_value=generated_gas_price)
+
+    assert legacy_transaction["gasPrice"]
+    tx_params = dict(legacy_transaction)
+    for i in range(3):
+        pending_tx.params = tx_params
+        old_gas_price = tx_params["gasPrice"]
+        old_nonce = tx_params["nonce"]
+        tx_params = speedup_strategy.execute(pending_tx)
+
+        current_gas_price = tx_params["gasPrice"]
+        assert current_gas_price != old_gas_price
+        assert current_gas_price == math.ceil(old_gas_price * (1 + speedup_percentage))
+        assert tx_params["nonce"] == old_nonce
+
+    # generated gas price is None - same results as before
+    mocker.patch.object(w3.eth, "generate_gas_price", return_value=None)  # set to None
+    for i in range(3):
+        tx_params = dict(legacy_transaction)
+        pending_tx.params = tx_params
+        old_gas_price = tx_params["gasPrice"]
+        old_nonce = tx_params["nonce"]
+        tx_params = speedup_strategy.execute(pending_tx)
+
+        current_gas_price = tx_params["gasPrice"]
+        assert current_gas_price != old_gas_price
+        assert current_gas_price == math.ceil(old_gas_price * (1 + speedup_percentage))
+        assert tx_params["nonce"] == old_nonce
+
+    # increase generated gas price more than existing gas price in legacy tx
+    tx_params = dict(legacy_transaction)
+    pending_tx.params = tx_params
+    generated_gas_price = tx_params["gasPrice"] * 2  # > what is in tx
+    mocker.patch.object(w3.eth, "generate_gas_price", return_value=generated_gas_price)
+
+    old_gas_price = tx_params["gasPrice"]
+    old_nonce = tx_params["nonce"]
+    updated_tx_params = speedup_strategy.execute(pending_tx)
+
+    current_gas_price = updated_tx_params["gasPrice"]
+    assert current_gas_price != old_gas_price
+    assert current_gas_price == math.ceil(
+        generated_gas_price * (1 + speedup_percentage)
+    )
+    assert updated_tx_params["nonce"] == old_nonce

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -58,10 +58,7 @@ def test_timeout_strategy(w3, mocker):
 
     assert len(warnings) == 1
     warning = warnings[0]["log_format"]
-    assert (
-        f"[pending_timeout] Transaction {pending_tx.txhash.hex()} will timeout in"
-        in warning
-    )
+    assert f"[timeout] Transaction {pending_tx.txhash.hex()} will timeout in" in warning
 
     # 3) close to timeout but not quite (5s short)
     pending_tx.created = (now - timedelta(seconds=(TIMEOUT - 5))).timestamp()


### PR DESCRIPTION
Based over #24 

Related to #14

Fixes #18, #20 